### PR TITLE
matplotlib-inline 0.1.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "matplotlib-inline" %}
-{% set version = "0.1.2" %}
+{% set version = "0.1.6" %}
 
 package:
   name: {{ name|lower }}
@@ -7,19 +7,21 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: f41d5ff73c9f5385775d5c0bc13b424535c8402fe70ea8210f93e11f3683993e
+  sha256: f887e5f10ba98e8d2b150ddcf4702c1e5f8b3a20005eb0f74bfdbd360ee6f304
 
 build:
-  noarch: python
-  number: 2
-  script: "{{ PYTHON }} -m pip install . -vv"
+  number: 0
+  skip: True  # [py<35]
+  script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
-    - python  >=3.6
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python  >=3.6
+    - python
     - traitlets
 
 test:
@@ -38,7 +40,7 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE
-  summary: 'Inline Matplotlib backend for Jupyter'
+  summary: Inline Matplotlib backend for Jupyter
   dev_url: https://github.com/ipython/matplotlib-inline
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,6 +42,7 @@ about:
   license_file: LICENSE
   summary: Inline Matplotlib backend for Jupyter
   dev_url: https://github.com/ipython/matplotlib-inline
+  doc_url: https://github.com/ipython/matplotlib-inline/blob/master/README.md
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
License: https://github.com/ipython/matplotlib-inline/blob/0.1.6/LICENSE
Requirements: https://github.com/ipython/matplotlib-inline/blob/0.1.6/setup.cfg

Actions:
1. Remove `noarch: python`
2. Reset build number
3. Skip `py<35`
4. Add `setuptools` and `wheel` to `host`
5. Fix `python` in `host` and `run`
6. Add `doc_url`