### PR TITLE
matplotlib-inline 0.2.2 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,18 +1,18 @@
 {% set name = "matplotlib-inline" %}
-{% set version = "0.2.1" %}
+{% set version = "0.2.2" %}
+{% set test_extra = "no" %}
+
 # When building out the initial package set for a new Python version the
 # recommendation is to run tests without ipython, then build
 # ipython, and then run tests with `test_extra="yes"` to test matplotlib_inline.backend_inline.
 # For a new python version, always build the package in pair with ipython.
-{% set test_extra = "no" %}
-
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/matplotlib_inline-{{ version }}.tar.gz
-  sha256: e1ee949c340d771fc39e241ea75683deb94762c8fa5f2927ec57c83c4dffa9fe
+  sha256: 72f3fe8fce36b70d4a5b612f899090cd0401deddc4ea90e1572b9f4bfb058c79
 
 build:
   number: 0
@@ -29,7 +29,6 @@ requirements:
     - traitlets
 
 test:
-{% if test_extra == 'yes' %}
   imports:
     - matplotlib_inline
     - matplotlib_inline.backend_inline
@@ -40,12 +39,10 @@ test:
   commands:
     - pip check
     - python -c "from matplotlib_inline.backend_inline import show"
-{% else %}
   requires:
     - pip
   commands:
     - pip check
-{% endif %}
 
 about:
   home: https://github.com/ipython/matplotlib-inline

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,11 +7,11 @@
 # ipython, and then run tests with `test_extra="yes"` to test matplotlib_inline.backend_inline.
 # For a new python version, always build the package in pair with ipython.
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/matplotlib_inline-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
   sha256: 72f3fe8fce36b70d4a5b612f899090cd0401deddc4ea90e1572b9f4bfb058c79
 
 build:
@@ -35,14 +35,12 @@ test:
   requires:
     - pip
     # matplotlib_inline/backend_inline.py imports matplotlib.
-    - matplotlib-base
+    - matplotlib
+    # matplotlib_inline/backend_inline.py imports ipython.
+    - ipython
   commands:
     - pip check
     - python -c "from matplotlib_inline.backend_inline import show"
-  requires:
-    - pip
-  commands:
-    - pip check
 
 about:
   home: https://github.com/ipython/matplotlib-inline
@@ -50,6 +48,9 @@ about:
   license_family: BSD
   license_file: LICENSE
   summary: Inline Matplotlib backend for Jupyter
+  description: |
+    This package provides support for matplotlib to display figures
+    directly inline in the Jupyter notebook and related clients, as shown below.
   dev_url: https://github.com/ipython/matplotlib-inline
   doc_url: https://github.com/ipython/matplotlib-inline/blob/master/README.md
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "matplotlib-inline" %}
-{% set version = "0.2.2" %}
+{% set version = "0.2.1" %}
 {% set test_extra = "no" %}
 
 # When building out the initial package set for a new Python version the
@@ -35,7 +35,7 @@ test:
   requires:
     - pip
     # matplotlib_inline/backend_inline.py imports matplotlib.
-    - matplotlib
+    - matplotlib-base
     # matplotlib_inline/backend_inline.py imports ipython.
     - ipython
   commands:


### PR DESCRIPTION
matplotlib-inline 0.2.2 

**Destination channel:** Defaults

### Links

- [PKG-16532]
- dev_url:        https://github.com/ipython/matplotlib-inline/tree/0.2.2
- conda_forge:    https://github.com/conda-forge/matplotlib-inline-feedstock
- pypi:           https://pypi.org/project/matplotlib-inline/0.2.2
- pypi inspector: https://inspector.pypi.io/project/matplotlib-inline/0.2.2

### Explanation of changes:

- new version number


[PKG-16532]: https://anaconda.atlassian.net/browse/PKG-16532?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ